### PR TITLE
Remove script tags for charting library, use import instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "core-js": "^2.4.1",
     "ie-shim": "^0.1.0",
     "reflect-metadata": "^0.1.3",
-    "rxjs": "^5.2.0",
+    "rxjs": "^5.4.2",
     "zone.js": "^0.8.1"
   },
   "devDependencies": {

--- a/src/app/chart_component/chart.component.ts
+++ b/src/app/chart_component/chart.component.ts
@@ -2,7 +2,9 @@ import {Component, OnInit} from '@angular/core';
 import {ChartService} from '../chart_service/chart.service';
 
 declare var CIQ: any;
-declare var $$$: any;
+import * as _exports from '../../chartiq_library/js/chartiq';
+var CIQ = _exports.CIQ;
+var $$$ = _exports.$$$;
 
 @Component({
   selector: 'chart',

--- a/src/app/chart_component/chart.component.ts
+++ b/src/app/chart_component/chart.component.ts
@@ -1,7 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {ChartService} from '../chart_service/chart.service';
 
-declare var CIQ: any;
 import * as _exports from '../../chartiq_library/js/chartiq';
 var CIQ = _exports.CIQ;
 var $$$ = _exports.$$$;

--- a/src/app/chart_service/chart.service.ts
+++ b/src/app/chart_service/chart.service.ts
@@ -1,4 +1,3 @@
-declare var CIQ: any;
 import * as _exports from '../../chartiq_library/js/chartiq';
 import '../../chartiq_library/js/quoteFeedSamples'
 var CIQ = _exports.CIQ;

--- a/src/app/chart_service/chart.service.ts
+++ b/src/app/chart_service/chart.service.ts
@@ -1,4 +1,7 @@
 declare var CIQ: any;
+import * as _exports from '../../chartiq_library/js/chartiq';
+import '../../chartiq_library/js/quoteFeedSamples'
+var CIQ = _exports.CIQ;
 
 export class ChartService{
 

--- a/src/app/drawing_toolbar_component/drawing.toolbar.component.ts
+++ b/src/app/drawing_toolbar_component/drawing.toolbar.component.ts
@@ -1,7 +1,8 @@
 import {Component, Output, EventEmitter} from '@angular/core'
 import {TitlecasePipe} from '../pipes/title.case.pipe'
 
-declare var CIQ: any;
+import * as _exports from '../../chartiq_library/js/chartiq';
+var CIQ = _exports.CIQ;
 
 @Component({
   selector: 'drawing-toolbar',

--- a/src/app/timezone_dialog_component/timezone.dialog.component.ts
+++ b/src/app/timezone_dialog_component/timezone.dialog.component.ts
@@ -1,6 +1,5 @@
 import {Component, Output, EventEmitter} from '@angular/core'
 
-declare var CIQ: any;
 import * as _exports from '../../chartiq_library/js/chartiq';
 var CIQ = _exports.CIQ;
 

--- a/src/app/timezone_dialog_component/timezone.dialog.component.ts
+++ b/src/app/timezone_dialog_component/timezone.dialog.component.ts
@@ -1,6 +1,8 @@
 import {Component, Output, EventEmitter} from '@angular/core'
 
 declare var CIQ: any;
+import * as _exports from '../../chartiq_library/js/chartiq';
+var CIQ = _exports.CIQ;
 
 @Component({
   selector: 'timezone-dialog',

--- a/src/app/ui_component/ui.component.ts
+++ b/src/app/ui_component/ui.component.ts
@@ -7,7 +7,6 @@ import {Colorpicker} from '../colorpicker_component/colorpicker'
 import {OverlayMenu} from '../overlay_menu_component/overlay.menu'
 
 import * as _exports from '../../chartiq_library/js/chartiq';
-declare var CIQ: any;
 var CIQ = _exports.CIQ;
 
 @Component({

--- a/src/app/ui_component/ui.component.ts
+++ b/src/app/ui_component/ui.component.ts
@@ -6,7 +6,9 @@ import {TimezoneDialog} from '../timezone_dialog_component/timezone.dialog.compo
 import {Colorpicker} from '../colorpicker_component/colorpicker'
 import {OverlayMenu} from '../overlay_menu_component/overlay.menu'
 
+import * as _exports from '../../chartiq_library/js/chartiq';
 declare var CIQ: any;
+var CIQ = _exports.CIQ;
 
 @Component({
     selector: 'chart-ui',

--- a/src/chartiq_library/js/chartiq.js
+++ b/src/chartiq_library/js/chartiq.js
@@ -1,0 +1,8 @@
+(function(exports){
+    exports.message = console.log("This is a stubbed file to show where chartiq.js should go")
+    exports.CIQ={};
+    exports.CIQ.ChartEngine={};
+    exports.CIQ.QuoteFeed={};
+    exports.$$$=function(x){};
+    return exports;
+})

--- a/src/chartiq_library/js/quoteFeedSamples.js
+++ b/src/chartiq_library/js/quoteFeedSamples.js
@@ -1,0 +1,1 @@
+// Replace this file with a QuoteFeed of your own implementation

--- a/src/index.html
+++ b/src/index.html
@@ -12,22 +12,6 @@
 		<link rel="stylesheet" type="text/css" href="chartiq_library/css/perfect-scrollbar.css" media="screen"/>
 		<link rel="stylesheet" href="app/css/CIQ_Seed.css">
 
-		<!-- The ChartIQ library -->
-		<script src="chartiq_library/js/thirdparty/excanvas.js"></script>
-		<script src="chartiq_library/js/thirdparty/ie8.js"></script>
-		<script src="chartiq_library/js/thirdparty/iscroll.js"></script>
-		<script src="chartiq_library/js/thirdparty/object-observe.js"></script>
-		<script src="chartiq_library/js/thirdparty/perfect-scrollbar.jquery.js"></script>
-		<script src="chartiq_library/js/thirdparty/splines.js"></script>
-		<script src="chartiq_library/js/thirdparty/webcomponents-lite.min.js"></script>
-		<script src="chartiq_library/js/chartiq.js"></script>
-		<script src="chartiq_library/js/plugin.js"></script>
-		<script src="chartiq_library/js/quoteFeedBarChart.js"></script>
-		<script src="chartiq_library/js/quoteFeedSamples.js"></script>
-		<script src="chartiq_library/js/quoteFeedSimulator.js"></script>
-		<script src="chartiq_library/js/quoteFeedXignite.js"></script>
-		<script src="chartiq_library/js/translations.js"></script>
-		<script src="chartiq_library/js/addOns.js"></script>
 	</head>
 
 	<body class="ciq-night">

--- a/tsconfig.aot.json
+++ b/tsconfig.aot.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowJs":true,
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "allowUnreachableCode":true,
     "target": "es5",
     "module": "commonjs",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,16 @@ var defaultConfig = {
 
   resolve: {
     extensions: [ '.ts', '.js' ],
-    modules: [ path.resolve(__dirname, 'node_modules') ]
+    modules: [
+      path.resolve(__dirname, 'node_modules'),
+      path.resolve(__dirname, 'src', 'chartiq_library', 'js'),
+      './src/chartiq_library/js/'
+      // path.resolve(__dirname, 'src', 'chartiq_library', 'css')
+    ],
+    alias: {
+      // chartiq: path.resolve(__dirname, 'chartiq.bundle.js' ),
+      chartiqEntry: './chartiq.entry.js'
+    }
   },
 
   devServer: {


### PR DESCRIPTION
Resolves Kanbanize ticket [2577](https://chartiq.kanbanize.com/ctrl_board/15/cards/2577/details)

Uses ES6 import instead of including script tags on template