### PR TITLE
Throw an error message when library isn't loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 [ ![Codeship Status for ChartIQ/Charting-Library---Angular-Seed-Project](https://app.codeship.com/projects/0b85d6c0-4010-0135-fa79-62e905eb1dfe/status?branch=master)](https://app.codeship.com/projects/229967)
 [![dependencies Status](https://david-dm.org/ChartIQ/Charting-Library---Angular-2.0-Seed-Project/status.svg)](https://david-dm.org/ChartIQ/Charting-Library---Angular-2.0-Seed-Project)
 
+- [Questions and support](#questions-and-support)
+- [Requirements](#requirements)
+- [Getting started](#getting-started)
+- [Contributing to this project](#contributing-to-this-project)
+
 A basic build of the ChartIQ library within the Angular 2.0 framework. This provides an example of how to implement the most common elements in the charting library. This is not a comprehensive example, more like a good starting point for an Angular developer.
 
 ## Questions and support
@@ -19,11 +24,11 @@ If you have questions or get stuck using this project or the ChartIQ library, th
 ## Getting started
 
 - Clone this repository.
-- Create two symlinks to the ChartIQ library js and css folders within the directory "src/chartiq_library". The new file structure addition should be "src/chartiq_library/js" and "src/chartiq_library/css".
-- Run `npm install` to install dependencies. There shouldn't be any need for installing node modules globally.
-- Run `npm start` to fire up the dev server.
+- Extract the contents of your zipped copy of the library into `src/chartiq_library/`. You should now have the folders `src/chartiq_library/css` and `src/chartiq_library/js`. You may be prompted about overwriting the contents of `src/chartiq_librar/js`. These pre-existing files are just stub files and should be overwritten.
+- Run `npm install` to install dependencies. It is strongly recommended to not have any of the dependencies installed globally.
+- Run `npm start` to start up the dev server.
 - Open your browser to [`http://localhost:3000`](http://localhost:3000).
-- If you want to use another port, open `package.json` file, then change the `server` script from `--port 3000` to the desired port number. A full list of webpack-dev-server command line options can be found [here](https://webpack.github.io/docs/webpack-dev-server.html#webpack-dev-server-cli).
+- If you want to use another port, open `package.json` file, then change the `server` script from `--port 3000` to the desired port number. A full list of webpack-dev-server command line options can be found [here](https://webpack.js.org/api/cli/#common-options).
 
 ## Contributing to this project
 

--- a/src/chartiq_library/js/chartiq.js
+++ b/src/chartiq_library/js/chartiq.js
@@ -1,8 +1,11 @@
-(function(exports){
-    exports.message = console.log("This is a stubbed file to show where chartiq.js should go")
-    exports.CIQ={};
-    exports.CIQ.ChartEngine={};
-    exports.CIQ.QuoteFeed={};
-    exports.$$$=function(x){};
-    return exports;
-})
+(function(){
+  exports.CIQ = {};
+  exports.CIQ.ChartEngine = {};
+  exports.CIQ.QuoteFeed = {};
+  exports.CIQ.Studies = {};
+  exports.$$$ = function(x) {};
+  throw new Error(
+    'ChartIQ library not loaded. Please add your copy to src/chartiq_library. ' +
+    '(See README.md for more details.)'
+  );
+}());


### PR DESCRIPTION
If you try to start the project without adding in the charting library, the application will compile but now it will throw a helpful error message in the console for you as well:
![console](https://user-images.githubusercontent.com/2344456/28843663-ff98dd1e-76cf-11e7-967a-9614ca618a04.png)