### PR TITLE
change CIQ variable declaration

### DIFF
--- a/src/app/colorpicker_component/colorpicker.ts
+++ b/src/app/colorpicker_component/colorpicker.ts
@@ -1,6 +1,7 @@
 import {Component, ElementRef, EventEmitter, Output} from '@angular/core'
 
-declare var CIQ: any;
+import * as _exports from '../../chartiq_library/js/chartiq';
+var CIQ = _exports.CIQ;
 
 @Component({
   selector: 'colorpicker',

--- a/src/app/overlay_menu_component/overlay.menu.ts
+++ b/src/app/overlay_menu_component/overlay.menu.ts
@@ -1,6 +1,7 @@
 import {Component, ElementRef, EventEmitter, Output} from '@angular/core'
 
-declare var CIQ: any;
+import * as _exports from '../../chartiq_library/js/chartiq';
+var CIQ = _exports.CIQ;
 
 @Component({
   selector: 'overlay-menu',

--- a/src/app/study_dialog_component/study.dialog.component.ts
+++ b/src/app/study_dialog_component/study.dialog.component.ts
@@ -1,7 +1,8 @@
 import {Component, NgZone, Output, EventEmitter} from '@angular/core'
 import {FilterByPropertyPipe} from '../pipes/property.filter.pipe'
 
-declare var CIQ: any;
+import * as _exports from '../../chartiq_library/js/chartiq';
+var CIQ = _exports.CIQ;
 
 @Component({
   selector: 'study-dialog',

--- a/src/app/theme_dialog_component/theme.dialog.component.ts
+++ b/src/app/theme_dialog_component/theme.dialog.component.ts
@@ -1,7 +1,8 @@
 import {Component, NgZone, Output, EventEmitter} from '@angular/core'
 import {Colorpicker} from '../colorpicker_component/colorpicker'
 
-declare var CIQ: any;
+import * as _exports from '../../chartiq_library/js/chartiq';
+var CIQ = _exports.CIQ;
 
 @Component({
   selector: 'theme-dialog',


### PR DESCRIPTION
There are some issues with some of the components having CIQ be undefined when CIQ was declared using `declare var CIQ: any;` Was getting the following error: `ChartUI.html:30 ERROR ReferenceError: CIQ is not defined`
 
Updated the declaration on the different components (colorpicker, overlay.menu, study.dialog, and theme.dialog) using this method and these components now work correctly.

