### PR TITLE
Sample implementation for CIQ.Tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "angular2-template-loader": "^0.6.2",
     "awesome-typescript-loader": "^5.2.1",
     "css-loader": "^1.0.0",
+    "jquery": "^3.3.1",
     "raw-loader": "^0.5.1",
     "to-string-loader": "^1.1.4",
     "typescript": "^3.1.1",

--- a/src/app/chart_component/chart.component.ts
+++ b/src/app/chart_component/chart.component.ts
@@ -2,6 +2,8 @@ import {Component, OnInit} from '@angular/core';
 import {ChartService} from '../chart_service/chart.service';
 
 import * as _exports from '../../chartiq_library/js/chartiq';
+// Uncomment this line to include addOns to your project
+// import 'addOns'
 
 let CIQ:any = _exports.CIQ;
 let $$$:any = _exports.$$$;
@@ -29,6 +31,8 @@ export class ChartComponent implements OnInit {
     this.ciq.setPeriodicityV2(1, 5);
     this.chartService.attachQuoteFeed(this.ciq);
     this.ciq.newChart("IBM");
+    // Comment this line in to add the tooltip when crosshairs are enabled
+    // new CIQ.Tooltip({stx:this.ciq, ohl:true})
   }
 
   // https://angular.io/docs/ts/latest/api/core/index/OnDestroy-class.html

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,11 @@ var webpackConfig = {
         // your Angular Async Route paths relative to this root directory
       }
     ),
+
+    new webpack.ProvidePlugin({
+      jQuery: 'jquery',
+      $: 'jquery'
+    })
   ],
 
   module: {


### PR DESCRIPTION
Adds sample implementation of CIQ.Tooltip. Adds jQuery as a dependency and provides it to addOns via [Webpack Provide Plugin](https://webpack.js.org/plugins/provide-plugin/) so it is not necessary to edit addOns.js itself