### PR TITLE
22589 exclude prototype functions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = space
+indent_style = tabs
 indent_size = 2
 end_of_line = lf
 insert_final_newline = true

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -203,7 +203,10 @@ export class ChartService {
 	}
 
 	getDrawingToolList() {
-		const list = CIQ.Drawing.getDrawingToolList({});
+	const list = CIQ.Drawing.getDrawingToolList({
+		'ciqInheritsFrom':true,
+		'stxInheritsFrom':true
+	});
 		return Object.keys(list).sort();
 	}
 

--- a/src/app/services/chart.service.ts
+++ b/src/app/services/chart.service.ts
@@ -203,10 +203,11 @@ export class ChartService {
 	}
 
 	getDrawingToolList() {
-	const list = CIQ.Drawing.getDrawingToolList({
-		'ciqInheritsFrom':true,
-		'stxInheritsFrom':true
-	});
+		const list = CIQ.Drawing.getDrawingToolList({
+		// These prototype functions are scheduled for removal in an upcoming release. For now ignore them to prevent errors.
+			'ciqInheritsFrom':true,
+			'stxInheritsFrom':true
+		});
 		return Object.keys(list).sort();
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,8 +5,9 @@ import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
 if (environment.production) {
-  enableProdMode();
+	enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.error(err));
+platformBrowserDynamic()
+	.bootstrapModule(AppModule)
+	.catch(err => console.error(err));


### PR DESCRIPTION
- Explicitly excludes prototype functions in getDrawingList.
- Changes EditorConfig to use tabs so it doesn't conflict with Prettier settings.